### PR TITLE
Solved the typo in the argparse default values and import issue.

### DIFF
--- a/construct_data.py
+++ b/construct_data.py
@@ -355,15 +355,15 @@ if __name__ == "__main__":
                         # then check if we should append or not
                         if word_counts[word] > num_sentences:
                             append_to_dataset = False
-                if True not in list(found_words_dict.values()):  # means this is a term-negative labeled data point!
-                    # Label: [0, 1]
-                    orig_classification[i_word + 1] = 1.
-                    word_counts['UNK'] = word_counts['UNK'] + 1
-                    if word_counts['UNK'] > 1.2 * max(
-                            [word_counts[word] for word in TARG]) + 1:  # keep the UNKs down!!! We want balance!!!
-                        append_to_dataset = False
-                        word_counts['UNK'] = word_counts[
-                                                 'UNK'] - 1  # so we actually won't count this one since we're not appending
+                    if True not in list(found_words_dict.values()):  # means this is a term-negative labeled data point!
+                        # Label: [0, 1]
+                        orig_classification[i_word + 1] = 1.
+                        word_counts['UNK'] = word_counts['UNK'] + 1
+                        if word_counts['UNK'] > 1.2 * max(
+                                [word_counts[word] for word in TARG]) + 1:  # keep the UNKs down!!! We want balance!!!
+                            append_to_dataset = False
+                            word_counts['UNK'] = word_counts[
+                                                     'UNK'] - 1  # so we actually won't count this one since we're not appending
 
                 # What will we call "original text" and "generated text"
 

--- a/construct_data.py
+++ b/construct_data.py
@@ -18,7 +18,7 @@ import torch
 import torch.nn.functional as F
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
-from .utils import top_k_top_p_filtering
+from utils import top_k_top_p_filtering
 
 nlp = spacy.load("en_core_web_sm")
 
@@ -69,8 +69,8 @@ if __name__ == "__main__":
                         help="base name of pickle files to write data set to"
                         )
     parser.add_argument("--target-words",
-                        default="sexist slurs",
-                        help="words to target, separated by commas; e.g. 'cat,dog,mouse'\n'sexist slurs' is a special value for this argument"
+                        default="sexist_slurs",
+                        help="words to target, separated by commas; e.g. 'cat,dog,mouse'\n'sexist_slurs' is a special value for this argument"
                         )
     parser.add_argument("--pretrained-model",
                         default="gpt2",


### PR DESCRIPTION
I noticed that there is a serious typo in the default "--target-words" argument that leads to the file "sexist_slurs.txt" would never be read by the system. 
Simply change the "sexist slurs" to "sexist_slurs" will solve this issue. 
Also, I removed the "." from .utils in the import statement. 